### PR TITLE
AO3-5519 AO3-5883 AO3-5886 Only admins can mark comments as spam

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -116,6 +116,16 @@ module CommentsHelper
     is_author_of?(comment) && comment.count_all_comments == 0 && !comment_parent_hidden?(comment)
   end
 
+  # Can mark a spam comment ham.
+  def can_mark_comment_ham?(comment)
+    comment.pseud.nil? && !comment.approved? && policy(comment).can_mark_comment_ham?
+  end
+
+  # Can makr a ham comment spam.
+  def can_mark_comment_spam?(comment)
+    comment.pseud.nil? && comment.approved? && policy(comment).can_mark_comment_spam?
+  end
+
   def comment_parent_hidden?(comment)
     parent = comment.ultimate_parent
     (parent.respond_to?(:hidden_by_admin) && parent.hidden_by_admin) ||

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -13,8 +13,12 @@ class CommentPolicy < ApplicationPolicy
     (can_delete_comment? || author_of?(record.ultimate_parent))
   end
 
+  def can_mark_comment_ham?
+    can_delete_comment?
+  end
+
   alias_method :destroy?, :can_delete_comment?
-  alias_method :approve?, :can_delete_comment?
+  alias_method :approve?, :can_mark_comment_ham?
   alias_method :reject?, :can_mark_comment_spam?
 
   private

--- a/app/views/comments/_comment_actions.html.erb
+++ b/app/views/comments/_comment_actions.html.erb
@@ -17,7 +17,7 @@
       <%= edit_comment_link comment %>
     </li>
   <% end %>
-  <% if comment.pseud.nil? and policy(comment).can_mark_comment_spam? %>
+  <% if can_mark_comment_spam?(comment) || can_mark_comment_ham?(comment) %>
     <li id="tag_comment_as_spam_link_<%= comment.id %>">
       <%= tag_comment_as_spam_link comment %>
     </li>

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -127,7 +127,7 @@ describe Admin::SettingsController do
           )
         end
 
-        it "allows admins with support role to update spam setting" do
+        it "allows admins with support role to update support form settings" do
           admin.update(roles: ["support"])
           fake_login_admin(admin)
 

--- a/spec/controllers/admin/user_creations_controller_spec.rb
+++ b/spec/controllers/admin/user_creations_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::UserCreationsController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  describe "GET #hide" do    
+  describe "PUT #hide" do    
     let(:admin) { create(:admin) }
     let(:work) { create(:work) }
 
@@ -43,7 +43,7 @@ describe Admin::UserCreationsController do
     end
   end
 
-  describe "GET #set_spam" do
+  describe "PUT #set_spam" do
     let(:admin) { create(:admin) }
     let(:work) { create(:work) }
 
@@ -80,7 +80,7 @@ describe Admin::UserCreationsController do
     end
   end
 
-  describe "GET #destroy" do
+  describe "DELETE #destroy" do
     let(:admin) { create(:admin) }
     let(:work) { create(:work) }
 


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5519
https://otwarchive.atlassian.net/browse/AO3-5883
https://otwarchive.atlassian.net/browse/AO3-5886

## Purpose

* Makes it so only admins can mark comments as ham.
* Tweaks a few spec descriptions.
