### PR TITLE
AO3-5886 Simplify authorization for marking comments spam

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -305,7 +305,7 @@ class CommentsController < ApplicationController
   # DELETE /comments/1
   # DELETE /comments/1.xml
   def destroy
-    authorize @comment if current_admin.present?
+    authorize @comment if logged_in_as_admin?
 
     parent = @comment.ultimate_parent
     parent_comment = @comment.reply_comment? ? @comment.commentable : nil
@@ -369,7 +369,7 @@ class CommentsController < ApplicationController
   end
 
   def reject
-    authorize @comment unless user_is_author_of_work(@comment)
+    authorize @comment if logged_in_as_admin?
     @comment.mark_as_spam!
     redirect_to_all_comments(@comment.ultimate_parent, show_comments: true)
   end
@@ -558,9 +558,5 @@ class CommentsController < ApplicationController
 
   def filter_params
     params.permit!
-  end
-
-  def user_is_author_of_work(comment)
-    current_user.is_a?(User) && current_user.is_author_of?(comment.ultimate_parent)
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -116,14 +116,17 @@ module CommentsHelper
     is_author_of?(comment) && comment.count_all_comments == 0 && !comment_parent_hidden?(comment)
   end
 
-  # Can mark a spam comment ham.
+  # Only an admin with proper authorization can mark a spam comment ham.
   def can_mark_comment_ham?(comment)
-    comment.pseud.nil? && !comment.approved? && policy(comment).can_mark_comment_ham?
+    return unless comment.pseud.nil? && !comment.approved? 
+    policy(comment).can_delete_comment?
   end
 
-  # Can makr a ham comment spam.
+  # An admin with proper authorization or a creator of the comment's ultimate
+  # parent (i.e. the work) can mark an approved comment as spam.
   def can_mark_comment_spam?(comment)
-    comment.pseud.nil? && comment.approved? && policy(comment).can_mark_comment_spam?
+    return unless comment.pseud.nil? && comment.approved? 
+    policy(comment).can_delete_comment? || is_author_of?(comment.ultimate_parent)
   end
 
   def comment_parent_hidden?(comment)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,8 +34,10 @@ class ApplicationPolicy
     false
   end
 
+  # Explicitly check that the user is an admin because regular users can have
+  # roles (e.g. archivist) as well, but we don't handle those with pundit.
   def user_has_roles?(roles)
-    user.respond_to?(:roles) && (user.roles & roles).present?
+    user&.is_a?(Admin) && user.respond_to?(:roles) && (user.roles & roles).present?
   end
 
   class Scope

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -9,11 +9,7 @@ class CommentPolicy < ApplicationPolicy
     user_has_roles?(DELETE_COMMENT_ROLES)
   end
 
-  def can_mark_comment_ham?
-    can_delete_comment?
-  end
-
   alias_method :destroy?, :can_delete_comment?
-  alias_method :approve?, :can_mark_comment_ham?
+  alias_method :approve?, :can_delete_comment?
   alias_method :reject?, :can_delete_comment?
 end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -852,6 +852,7 @@ describe CommentsController do
 
     context "when logged in as an admin" do
       before { fake_login_admin(create(:admin, roles: ["policy_and_abuse"])) }
+
       let(:admin) { create(:admin) }
       
       context "DELETE COMMENT" do


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-5886

## Purpose

* Remove authorship check when authorizing marking comments as spam (it's covered by the before actions)
* Finish removing unneeded methods from comment policy and update helper methods accordingly
* Make it clearer ApplicationPolicy is intended to be used by Admins, not Users

